### PR TITLE
Keep track of allocated capacity in RenderTarget

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ Release Notes
 #############
 
 *****************************
+0.6.2 - upcoming release
+*****************************
+
+Bugfixes:
+
+- Fix crash on G810 due to incorreclty passing actual number of keys to blend
+  (instead of up-aligned target capacity, required for SSE2). — issue #10.
+
+*****************************
 0.6.1 - current release
 *****************************
 

--- a/keyledsd/include/keyledsd/device/RenderLoop.h
+++ b/keyledsd/include/keyledsd/device/RenderLoop.h
@@ -41,18 +41,18 @@ namespace keyleds { namespace device {
  */
 class RenderTarget final
 {
-    static constexpr std::size_t   align_bytes = 32;
+    static constexpr std::size_t   align_bytes = 32;    // 16 is minimum for SSE2, 32 for AVX2
     static constexpr std::size_t   align_colors = align_bytes / sizeof(RGBAColor);
 public:
     using value_type = RGBAColor;
-    using size_type = std::size_t;
-    using difference_type = std::ptrdiff_t;
+    using size_type = unsigned int;                     // we don't need size_t extra range
+    using difference_type = signed int;
     using reference = value_type &;
     using const_reference = const value_type &;
     using iterator = value_type *;
     using const_iterator = const value_type *;
 public:
-                                RenderTarget(size_type numKeys);
+                                RenderTarget(size_type);
                                 RenderTarget(RenderTarget &&) noexcept;
     RenderTarget &              operator=(RenderTarget &&) noexcept;
                                 ~RenderTarget();
@@ -60,12 +60,12 @@ public:
     iterator                    begin() { return &m_colors[0]; }
     const_iterator              begin() const { return &m_colors[0]; }
     const_iterator              cbegin() const { return &m_colors[0]; }
-    iterator                    end() { return &m_colors[m_nbColors]; }
-    const_iterator              end() const { return &m_colors[m_nbColors]; }
-    const_iterator              cend() const { return &m_colors[m_nbColors]; }
-    bool                        empty() const { return false; }
-    size_type                   size() const noexcept { return m_nbColors; }
-    size_type                   max_size() const noexcept { return m_nbColors; }
+    iterator                    end() { return &m_colors[m_size]; }
+    const_iterator              end() const { return &m_colors[m_size]; }
+    const_iterator              cend() const { return &m_colors[m_size]; }
+    bool                        empty() const noexcept { return false; }
+    size_type                   size() const noexcept { return m_size; }
+    size_type                   capacity() const noexcept { return m_capacity; }
     value_type *                data() { return m_colors; }
     const value_type *          data() const { return m_colors; }
     reference                   operator[](size_type idx) { return m_colors[idx]; }
@@ -73,7 +73,8 @@ public:
 
 private:
     RGBAColor *                 m_colors;       ///< Color buffer. RGBAColor is a POD type
-    std::size_t                 m_nbColors;     ///< Number of items in m_colors
+    size_type                   m_size;         ///< Number of color entries
+    size_type                   m_capacity;     ///< Number of allocated color entries
 
     friend void swap(RenderTarget &, RenderTarget &) noexcept;
 };

--- a/keyledsd/src/tools/accelerated_mmx.c
+++ b/keyledsd/src/tools/accelerated_mmx.c
@@ -21,16 +21,19 @@
 
 void blend_mmx(uint8_t * restrict dst, const uint8_t * restrict src, unsigned length)
 {
-    __m64 * restrict dstv = (__m64 *)__builtin_assume_aligned(dst, 16);
-    const __m64 * restrict srcv = (const __m64 *)__builtin_assume_aligned(src, 16);
+    assert((uintptr_t)dst % 8 == 0);    // MMX requires 8-bytes aligned data
+    assert((uintptr_t)src % 8 == 0);    // MMX requires 8-bytes aligned data
+    assert(length != 0);                // allows inverting loop condition, makes gcc generate
+                                        // better loop code
+    assert(length % 2 == 0);            // we'll process entries 2 by 2 and don't want to be
+                                        // slowed by boundary checks
+
+    __m64 * restrict dstv = (__m64 *)__builtin_assume_aligned(dst, 8);
+    const __m64 * restrict srcv = (const __m64 *)__builtin_assume_aligned(src, 8);
 
     const __m64 zero = _mm_setzero_si64();
     const __m64 one = _mm_set1_pi16(1);
     const __m64 max = _mm_set1_pi16(256);
-
-    assert((uintptr_t)dst % 16 == 0);
-    assert((uintptr_t)src % 16 == 0);
-    assert(length % 4 == 0);
 
     length /= 2;
 

--- a/keyledsd/src/tools/accelerated_plain.c
+++ b/keyledsd/src/tools/accelerated_plain.c
@@ -18,14 +18,13 @@
 #include <stdint.h>
 #include "config.h"
 
-void blend_plain(uint8_t * __restrict a, const uint8_t * __restrict b, unsigned length)
+void blend_plain(uint8_t * restrict a, const uint8_t * restrict b, unsigned length)
 {
-    a = (uint8_t*)__builtin_assume_aligned(a, 16);
-    b = (const uint8_t*)__builtin_assume_aligned(b, 16);
+    assert((uintptr_t)a % 8 == 0);    // Not a requirement, but lets compiler optimize stuff
+    assert((uintptr_t)b % 8 == 0);    // Not a requirement, but lets compiler optimize stuff
 
-    assert((uintptr_t)a % 16 == 0);
-    assert((uintptr_t)b % 16 == 0);
-    assert(length % 16 == 0);
+    a = (uint8_t*)__builtin_assume_aligned(a, 8);
+    b = (const uint8_t*)__builtin_assume_aligned(b, 8);
 
     while (length-- > 0) {
         uint16_t alpha = b[3];

--- a/keyledsd/src/tools/accelerated_sse2.c
+++ b/keyledsd/src/tools/accelerated_sse2.c
@@ -21,6 +21,13 @@
 
 void blend_sse2(uint8_t * restrict dst, const uint8_t * restrict src, unsigned length)
 {
+    assert((uintptr_t)dst % 16 == 0);   // SSE2 requires 16-bytes aligned data
+    assert((uintptr_t)src % 16 == 0);   // SSE2 requires 16-bytes aligned data
+    assert(length != 0);                // allows inverting loop condition, makes gcc generate
+                                        // better loop code
+    assert(length % 4 == 0);            // we'll process entries 4 by 4 and don't want to be
+                                        // slowed by boundary checks
+
     __m128i * restrict dstv = (__m128i *)__builtin_assume_aligned(dst, 16);
     const __m128i * restrict srcv = (const __m128i *)__builtin_assume_aligned(src, 16);
 
@@ -28,9 +35,6 @@ void blend_sse2(uint8_t * restrict dst, const uint8_t * restrict src, unsigned l
     const __m128i one = _mm_set1_epi16(1);
     const __m128i max = _mm_set1_epi16(256);
 
-    assert((uintptr_t)dst % 16 == 0);
-    assert((uintptr_t)src % 16 == 0);
-    assert(length % 4 == 0);
     length /= 4;
 
     do {


### PR DESCRIPTION
Fixes issue #10.
RenderTarget allocates properly aligned storage, and aligning the key count as well, so that optimized functions don't have to handle half-run cases. For consistency, this modified key count is not exposed:`target.size()` returns the requested number of keys, not including padding keys added to align the buffer.

The crash comes from passing that `size()` to optimized functions, which properly reject it. They need to be passed the full allocated size. That's what this fixes: it keeps track of how many keys were allocated and uses the capacity instead of the size for optimized functions.

This also grabs the opportunity of switching `size_type` from `size_t` to `unsigned int`. I'll change it back when I see a 2-billion key keyboard.