### PR TITLE
RenderLoop.cxx -- Added missing numeric includes.

### DIFF
--- a/keyledsd/core/src/keyledsd/RenderLoop.cxx
+++ b/keyledsd/core/src/keyledsd/RenderLoop.cxx
@@ -16,6 +16,7 @@
  */
 #include "keyledsd/RenderLoop.h"
 
+#include <numeric>
 #include <algorithm>
 #include <cassert>
 #include <cerrno>


### PR DESCRIPTION
Fixes build.  Did not update versions or other change logs which I left for your consistency.

    error: ‘accumulate’ is not a member of ‘std’ 
    return RenderTarget(std::accumulate(
                             ^~~~~~~~~~