### PR TITLE
Relocate the Qt check into WITH_KEYLEDSD condition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,31 +30,33 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/lib")
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/bin")
 
 ##############################################################################
-# Work around Qt script selecting wrong tools while cross-compiling
-
-IF(CMAKE_CROSSCOMPILING)
-    execute_process(COMMAND qtchooser -qt=5 -print-env
-                    COMMAND grep ^QTTOOLDIR=
-                    COMMAND sed s/^QTTOOLDIR=\"\\\(.*\\\)\"$/\\1/
-                    OUTPUT_VARIABLE NATIVE_QT_BINDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-    set(QT_MOC_EXECUTABLE ${NATIVE_QT_BINDIR}/moc)
-    add_executable(Qt5::moc IMPORTED)
-    set_property(TARGET Qt5::moc PROPERTY IMPORTED_LOCATION ${QT_MOC_EXECUTABLE})
-    add_executable(Qt5::rcc IMPORTED)
-    set_property(TARGET Qt5::rcc PROPERTY IMPORTED_LOCATION ${NATIVE_QT_BINDIR}/rcc)
-    add_executable(Qt5::qdbuscpp2xml IMPORTED)
-    set_property(TARGET Qt5::qdbuscpp2xml PROPERTY IMPORTED_LOCATION ${NATIVE_QT_BINDIR}/qdbuscpp2xml)
-    add_executable(Qt5::qdbusxml2cpp IMPORTED)
-    set_property(TARGET Qt5::qdbuscpp2xml PROPERTY IMPORTED_LOCATION ${NATIVE_QT_BINDIR}/qdbusxml2cpp)
-ENDIF(CMAKE_CROSSCOMPILING)
-
-##############################################################################
 # Include subprojects
 
 add_subdirectory(libkeyleds)
 add_subdirectory(keyledsctl)
+
 IF (WITH_KEYLEDSD)
+
+##############################################################################
+# Work around Qt script selecting wrong tools while cross-compiling
+
+    IF(CMAKE_CROSSCOMPILING)
+        execute_process(COMMAND qtchooser -qt=5 -print-env
+                        COMMAND grep ^QTTOOLDIR=
+                        COMMAND sed s/^QTTOOLDIR=\"\\\(.*\\\)\"$/\\1/
+                        OUTPUT_VARIABLE NATIVE_QT_BINDIR OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+        set(QT_MOC_EXECUTABLE ${NATIVE_QT_BINDIR}/moc)
+        add_executable(Qt5::moc IMPORTED)
+        set_property(TARGET Qt5::moc PROPERTY IMPORTED_LOCATION ${QT_MOC_EXECUTABLE})
+        add_executable(Qt5::rcc IMPORTED)
+        set_property(TARGET Qt5::rcc PROPERTY IMPORTED_LOCATION ${NATIVE_QT_BINDIR}/rcc)
+        add_executable(Qt5::qdbuscpp2xml IMPORTED)
+        set_property(TARGET Qt5::qdbuscpp2xml PROPERTY IMPORTED_LOCATION ${NATIVE_QT_BINDIR}/qdbuscpp2xml)
+        add_executable(Qt5::qdbusxml2cpp IMPORTED)
+        set_property(TARGET Qt5::qdbuscpp2xml PROPERTY IMPORTED_LOCATION ${NATIVE_QT_BINDIR}/qdbusxml2cpp)
+    ENDIF(CMAKE_CROSSCOMPILING)
+
     add_subdirectory(keyledsd)
 ENDIF()
 IF (WITH_PYTHON)


### PR DESCRIPTION
Currently, keyledsd is the only part that requires Qt in the host
build environment, relocating this chunk within the
'IF (WITH_KEYLEDSD)' section allows host build without Qt to
continue without errors.

Signed-off-by: Kevin Pearson <kevin.pearson@ortmanconsulting.com>